### PR TITLE
Changing submodule URL format to https:// instead of git@github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pages"]
 	path = pages
-	url = git@github.com:square/SocketRocket.git
+	url = https://github.com/square/SocketRocket.git


### PR DESCRIPTION
The reason I want to request this is that we have several OSX slaves for a jenkins build which checks out an iOS project which is using PonyDebugger 

When it runs...

```
git submodule update --init --recursive
```

... it chokes because the slaves don't have publickeys set up with github and the git@github url format requires that.

Making this change will introduce consistency to your submodule url formats and eliminate the need for every machine cloning this project as a recursive submodule to have a public key set up with github.

Let me know if there is another way around this. Thanks!

Alex
