### PR TITLE
Minor fix to prevent barfing on url scheme asserts

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -265,7 +265,7 @@ static __strong NSData *CRLFCRLF;
     if (self) {
         assert(request.URL);
         _url = request.URL;
-        NSString *scheme = [_url scheme];
+        NSString *scheme = [[_url scheme] lowercaseString];
         
         _requestedProtocols = [protocols copy];
 


### PR DESCRIPTION
Set the url scheme to lowercaseString so void crashing on the asserts. The scheme is set to lowercase when used later in the code, so it should be done here as well.
