### PR TITLE
Add support for interfacing with Ping/Pong outside of SRWebSocket

### DIFF
--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -68,6 +68,8 @@ extern NSString *const SRWebSocketErrorDomain;
 // Send a UTF8 String or Data
 - (void)send:(id)data;
 
+- (void)sendPing:(NSData *)data;
+
 @end
 
 @protocol SRWebSocketDelegate <NSObject>
@@ -81,6 +83,7 @@ extern NSString *const SRWebSocketErrorDomain;
 - (void)webSocketDidOpen:(SRWebSocket *)webSocket;
 - (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error;
 - (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean;
+- (void)webSocket:(SRWebSocket *)webSocket didReceivePong:(NSData *)data;
 
 @end
 

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -705,6 +705,13 @@ static __strong NSData *CRLFCRLF;
     });
 }
 
+- (void)sendPing:(NSData *)data
+{
+    dispatch_async(_workQueue, ^{
+        [self _sendFrameWithOpcode:SROpCodePing data:data];
+    });
+}
+
 - (void)handlePing:(NSData *)pingData;
 {
     // Need to pingpong this off _callbackQueue first to make sure messages happen in order
@@ -715,9 +722,13 @@ static __strong NSData *CRLFCRLF;
     }];
 }
 
-- (void)handlePong;
+- (void)handlePong:(NSData *)data;
 {
-    // NOOP
+    if ([self.delegate respondsToSelector:@selector(webSocket:didReceivePong:)]) {
+        [self _performDelegateBlock:^{
+            [self.delegate webSocket:self didReceivePong:data];
+        }];
+    }
 }
 
 - (void)_handleMessage:(id)message
@@ -847,7 +858,7 @@ static inline BOOL closeCodeIsValid(int closeCode) {
             [self handlePing:frameData];
             break;
         case SROpCodePong:
-            [self handlePong];
+            [self handlePong:frameData];
             break;
         default:
             [self _closeWithProtocolError:[NSString stringWithFormat:@"Unknown opcode %d", opcode]];


### PR DESCRIPTION
This patch adds an interface to explicitly send a ping control frame (with optional data).  Additionally, it adds an optional delegate method that gets invoked when a pong is received.

These small changes make it easier to implement something like a watchdog state machine that ensures the connection is always healthy by periodically sending pings.
