### PR TITLE
Change "muust be compiled with ARC" to "must be compiled with ARC"

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -48,7 +48,7 @@
 #endif
 
 #if !__has_feature(objc_arc) 
-#error SocketRocket muust be compiled with ARC enabled
+#error SocketRocket must be compiled with ARC enabled
 #endif
 
 


### PR DESCRIPTION
Fix a typo in the error message if the user attempts to compile with project without ARC.
