### PR TITLE
Reset Build Settings to the defaults of #xcode5

### DIFF
--- a/SocketRocket.xcodeproj/project.pbxproj
+++ b/SocketRocket.xcodeproj/project.pbxproj
@@ -639,7 +639,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -676,7 +675,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
NOTE: I think, in this commit, I also reset some custom build settings. I recommend merging in this branch and then reapplying your custom build settings. That will be easier because many of the build settings were outdated. Also, that will take this branch off the SocketRocket Network graph.

I created a new Xcode Project called TestSocket
with the Cocoa Touch Static Library template and
reset the build settings of SocketRocket's project
& Cocoa Touch Static Library target to match those
of TestSocket.

I did not change any of the build settings for
other targets.

Doing this enables modules. This means you can
remove many of the linked frameworks, but I left
them.
