### PR TITLE
Remove errant assert(NO) in _sendFrameWithOpcode

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1328,8 +1328,6 @@ static const size_t SRFrameHeaderOverhead = 32;
         unmasked_payload = (uint8_t *)[data bytes];
     } else if ([data isKindOfClass:[NSString class]]) {
         unmasked_payload =  (const uint8_t *)[data UTF8String];
-    } else {
-        assert(NO);
     }
     
     if (payloadLength < 126) {


### PR DESCRIPTION
The assert located here was contradictory to the assert at the top of the function.  Up top, the assert implies that "data" can be nil.  The assert below (which I have removed) prevents pings from working from our server.
