### PR TITLE
Move SRStatusCode typedef into header file

### DIFF
--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -24,7 +24,7 @@ typedef enum {
     SR_CLOSED       = 3,
 } SRReadyState;
 
-typedef enum {
+typedef enum SRStatusCode : NSInteger {
     SRStatusCodeNormal = 1000,
     SRStatusCodeGoingAway = 1001,
     SRStatusCodeProtocolError = 1002,
@@ -79,7 +79,7 @@ extern NSString *const SRWebSocketErrorDomain;
 - (void)open;
 
 - (void)close;
-- (void)closeWithCode:(SRStatusCode)code reason:(NSString *)reason;
+- (void)closeWithCode:(NSInteger)code reason:(NSString *)reason;
 
 // Send a UTF8 String or Data.
 - (void)send:(id)data;
@@ -98,7 +98,7 @@ extern NSString *const SRWebSocketErrorDomain;
 
 - (void)webSocketDidOpen:(SRWebSocket *)webSocket;
 - (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error;
-- (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(SRStatusCode)code reason:(NSString *)reason wasClean:(BOOL)wasClean;
+- (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean;
 
 @end
 

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -602,7 +602,7 @@ static __strong NSData *CRLFCRLF;
     [self closeWithCode:-1 reason:nil];
 }
 
-- (void)closeWithCode:(SRStatusCode)code reason:(NSString *)reason;
+- (void)closeWithCode:(NSInteger)code reason:(NSString *)reason;
 {
     assert(code);
     dispatch_async(_workQueue, ^{


### PR DESCRIPTION
This is to easily enable developers to use an SRStatusCode value when closing a web socket.

The purpose of bc787cc is to be more conformant with [RFC 6455](https://tools.ietf.org/html/rfc6455), which states in [section 7.4.2](https://tools.ietf.org/html/rfc6455#section-7.4.2): `Status codes in the range 0-999 are not used.`
