### PR TITLE
Fix block retain cycles and rename local 'self' variables to avoid confusion

### DIFF
--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -49,7 +49,7 @@ extern NSString *const SRWebSocketErrorDomain;
 
 @interface SRWebSocket : NSObject <NSStreamDelegate>
 
-@property (nonatomic, assign) id <SRWebSocketDelegate> delegate;
+@property (nonatomic, weak) id <SRWebSocketDelegate> delegate;
 
 @property (nonatomic, readonly) SRReadyState readyState;
 @property (nonatomic, readonly, retain) NSURL *url;

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1425,9 +1425,6 @@ static const size_t SRFrameHeaderOverhead = 32;
 
 - (void)safeHandleEvent:(NSStreamEvent)eventCode stream:(NSStream *)aStream
 {
-    __strong typeof(self) strongSelf = self;
-    ((void)strongSelf);
-
     switch (eventCode) {
         case NSStreamEventOpenCompleted: {
             SRFastLog(@"NSStreamEventOpenCompleted %@", aStream);

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -478,10 +478,10 @@ static __strong NSData *CRLFCRLF;
     }
                         
     [self _readUntilHeaderCompleteWithCallback:^(SRWebSocket *webSocket,  NSData *data) {
-        CFHTTPMessageAppendBytes(_receivedHTTPHeaders, (const UInt8 *)data.bytes, data.length);
+        CFHTTPMessageAppendBytes(webSocket->_receivedHTTPHeaders, (const UInt8 *)data.bytes, data.length);
         
-        if (CFHTTPMessageIsHeaderComplete(_receivedHTTPHeaders)) {
-            SRFastLog(@"Finished reading headers %@", CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(_receivedHTTPHeaders)));
+        if (CFHTTPMessageIsHeaderComplete(webSocket->_receivedHTTPHeaders)) {
+            SRFastLog(@"Finished reading headers %@", CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(webSocket->_receivedHTTPHeaders)));
             [webSocket _HTTPHeadersDidFinish];
         } else {
             [webSocket _readHTTPHeader];
@@ -985,7 +985,7 @@ static const uint8_t SRPayloadLenMask   = 0x7F;
             [webSocket _closeWithProtocolError:@"Client must receive unmasked data"];
         }
         
-        size_t extra_bytes_needed = header.masked ? sizeof(_currentReadMaskKey) : 0;
+        size_t extra_bytes_needed = header.masked ? sizeof(webSocket->_currentReadMaskKey) : 0;
         
         if (header.payload_length == 126) {
             extra_bytes_needed += sizeof(uint16_t);
@@ -1016,7 +1016,7 @@ static const uint8_t SRPayloadLenMask   = 0x7F;
                 
                 
                 if (header.masked) {
-                    assert(mapped_size >= sizeof(_currentReadMaskOffset) + offset);
+                    assert(mapped_size >= sizeof(webSocket->_currentReadMaskOffset) + offset);
                     memcpy(webSocket->_currentReadMaskKey, ((uint8_t *)mapped_buffer) + offset, sizeof(webSocket->_currentReadMaskKey));
                 }
                 

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -110,8 +110,14 @@ static NSString *newSHA1String(const char *bytes, size_t length) {
     assert(length >= 0);
     assert(length <= UINT32_MAX);
     CC_SHA1(bytes, (CC_LONG)length, md);
-    
-    return [[NSData dataWithBytes:md length:CC_SHA1_DIGEST_LENGTH] base64EncodedStringWithOptions:0];
+
+    NSData *data = [NSData dataWithBytes:md length:CC_SHA1_DIGEST_LENGTH];
+    NSString *dataString;
+    if ([data respondsToSelector:@selector(base64EncodedStringWithOptions:)])
+        dataString = [data base64EncodedStringWithOptions:0];
+    else
+        dataString = [data base64Encoding];
+    return dataString;
 }
 
 @implementation NSData (SRWebSocket)
@@ -500,7 +506,10 @@ static __strong NSData *CRLFCRLF;
         
     NSMutableData *keyBytes = [[NSMutableData alloc] initWithLength:16];
     SecRandomCopyBytes(kSecRandomDefault, keyBytes.length, keyBytes.mutableBytes);
-    _secKey = [keyBytes base64EncodedStringWithOptions:0];
+    if ([keyBytes respondsToSelector:@selector(base64EncodedStringWithOptions:)])
+        _secKey = [keyBytes base64EncodedStringWithOptions:0];
+    else
+        _secKey = [keyBytes base64Encoding];
     assert([_secKey length] == 24);
     
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Upgrade"), CFSTR("websocket"));

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -111,7 +111,7 @@ static NSString *newSHA1String(const char *bytes, size_t length) {
     assert(length <= UINT32_MAX);
     CC_SHA1(bytes, (CC_LONG)length, md);
     
-    return [[NSData dataWithBytes:md length:CC_SHA1_DIGEST_LENGTH] base64Encoding];
+    return [[NSData dataWithBytes:md length:CC_SHA1_DIGEST_LENGTH] base64EncodedStringWithOptions:0];
 }
 
 @implementation NSData (SRWebSocket)
@@ -500,7 +500,7 @@ static __strong NSData *CRLFCRLF;
         
     NSMutableData *keyBytes = [[NSMutableData alloc] initWithLength:16];
     SecRandomCopyBytes(kSecRandomDefault, keyBytes.length, keyBytes.mutableBytes);
-    _secKey = keyBytes.base64Encoding;
+    _secKey = [keyBytes base64EncodedStringWithOptions:0];
     assert([_secKey length] == 24);
     
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Upgrade"), CFSTR("websocket"));

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -113,10 +113,11 @@ static NSString *newSHA1String(const char *bytes, size_t length) {
 
     NSData *data = [NSData dataWithBytes:md length:CC_SHA1_DIGEST_LENGTH];
     NSString *dataString;
-    if ([data respondsToSelector:@selector(base64EncodedStringWithOptions:)])
+    if ([data respondsToSelector:@selector(base64EncodedStringWithOptions:)]) {
         dataString = [data base64EncodedStringWithOptions:0];
-    else
+    } else {
         dataString = [data base64Encoding];
+    }
     return dataString;
 }
 
@@ -506,10 +507,11 @@ static __strong NSData *CRLFCRLF;
         
     NSMutableData *keyBytes = [[NSMutableData alloc] initWithLength:16];
     SecRandomCopyBytes(kSecRandomDefault, keyBytes.length, keyBytes.mutableBytes);
-    if ([keyBytes respondsToSelector:@selector(base64EncodedStringWithOptions:)])
+    if ([keyBytes respondsToSelector:@selector(base64EncodedStringWithOptions:)]) {
         _secKey = [keyBytes base64EncodedStringWithOptions:0];
-    else
+    } else {
         _secKey = [keyBytes base64Encoding];
+    }
     assert([_secKey length] == 24);
     
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Upgrade"), CFSTR("websocket"));


### PR DESCRIPTION
Several ivars were accessed in blocks, implicitly causing self to be retained. I verified that this caused a retain cycle on SRWebSocket, and these commits resolved the retain cycle for me.

Additionally, I renamed the local 'self' variables to avoid confusion with the 'self' instance pointer.