### PR TITLE
Evalute ssl cert chain with hostname policy for leaf cert.

### DIFF
--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -138,6 +138,7 @@ extern NSString *const SRHTTPResponseErrorKey;
 
 @interface NSMutableURLRequest (SRCertificateAdditions)
 
+// An array of SecCertificateRef's
 @property (nonatomic, retain) NSArray *SR_SSLPinnedCertificates;
 
 @end

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1502,8 +1502,6 @@ static const size_t SRFrameHeaderOverhead = 32;
 
 #pragma mark - NSStreamDelegate
 
-typedef void (^TrustEvalHandler)(SecTrustRef  _Nonnull, SecTrustResultType);
-
 - (void)stream:(NSStream *)aStream handleEvent:(NSStreamEvent)eventCode;
 {
     __weak typeof(self) weakSelf = self;
@@ -1538,8 +1536,8 @@ typedef void (^TrustEvalHandler)(SecTrustRef  _Nonnull, SecTrustResultType);
                 }
             }
 
-            __weak __block TrustEvalHandler weakTrustHandler;
-            TrustEvalHandler trustHandler = ^(SecTrustRef  _Nonnull trustRef, SecTrustResultType trustResult){
+            __weak __block SecTrustCallback weakTrustHandler;
+            SecTrustCallback trustHandler = ^(SecTrustRef  _Nonnull trustRef, SecTrustResultType trustResult){
                   OSStatus status = noErr;
                   if (trustResult == kSecTrustResultUnspecified || trustResult == kSecTrustResultProceed) {
                     _certTrusted = YES;
@@ -1558,7 +1556,7 @@ typedef void (^TrustEvalHandler)(SecTrustRef  _Nonnull, SecTrustResultType);
                           [weakSelf _failWithError:[NSError errorWithDomain:@"org.lolrus.SocketRocket" code:23556 userInfo:userInfo]];
                         });
                     } else {
-                        TrustEvalHandler strongTrustHandler = weakTrustHandler;
+                        SecTrustCallback strongTrustHandler = weakTrustHandler;
                         SecTrustEvaluateAsync(secTrust, _workQueue, strongTrustHandler);
                     }
 

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -1499,17 +1499,16 @@ static const size_t SRFrameHeaderOverhead = 32;
                 }
             }
 
-          if (!_certTrusted) {
-            dispatch_async(_workQueue, ^{
-              [self _failWithError:[NSError errorWithDomain:SRWebSocketErrorDomain code:23556 userInfo:[NSDictionary dictionaryWithObject:[NSString stringWithFormat:@"Invalid server cert"] forKey:NSLocalizedDescriptionKey]]];
-            });
-            return;
-          } else if (aStream == _outputStream) {
-            dispatch_async(_workQueue, ^{
-              [self didConnect];
-            });
-          }
-
+            if (!_certTrusted) {
+                dispatch_async(_workQueue, ^{
+                    [self _failWithError:[NSError errorWithDomain:SRWebSocketErrorDomain code:23556 userInfo:[NSDictionary dictionaryWithObject:[NSString stringWithFormat:@"Invalid server cert"] forKey:NSLocalizedDescriptionKey]]];
+                });
+                return;
+            } else if (aStream == _outputStream) {
+                dispatch_async(_workQueue, ^{
+                    [self didConnect];
+                });
+            }
         }
     }
 


### PR DESCRIPTION
Without pinning certs, evaluate trust by creating an ssl hostname policy.