### PR TITLE
Fix no ability to build tvOS framework for Apple TV Simulator from Xcode.

### DIFF
--- a/SocketRocket.xcodeproj/project.pbxproj
+++ b/SocketRocket.xcodeproj/project.pbxproj
@@ -712,7 +712,7 @@
 				PRODUCT_NAME = SocketRocket;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -748,7 +748,7 @@
 				PRODUCT_NAME = SocketRocket;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};


### PR DESCRIPTION
This should be set to `3` for Apple TV Simulator to be targetable.
`1` stands for iPhone/iTouch
`2` stands for iPad