### PR TITLE
Add 'sendData:', 'sendString:' and deprecate 'send:'.

### DIFF
--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -109,15 +109,45 @@ extern NSString *const SRHTTPResponseErrorKey;
 - (void)close;
 - (void)closeWithCode:(NSInteger)code reason:(NSString *)reason;
 
-// Send a UTF8 String or Data.
-- (void)send:(id)data;
+///--------------------------------------
+#pragma mark Send
+///--------------------------------------
 
-// Send Data (can be nil) in a ping message.
+/**
+ Send a UTF-8 string or binary data to the server.
+
+ @param message UTF-8 String or Data to send.
+
+ @deprecated Please use `sendString:` or `sendData` instead.
+ */
+- (void)send:(id)message __attribute__((deprecated("Please use `sendString:` or `sendData` instead.")));
+
+/**
+ Send a UTF-8 String to the server.
+
+ @param string String to send.
+ */
+- (void)sendString:(NSString *)string;
+
+/**
+ Send binary data to the server.
+
+ @param data Data to send.
+ */
+- (void)sendData:(NSData *)data;
+
+/**
+ Send Ping message to the server with optional data.
+
+ @param data Instance of `NSData` or `nil`.
+ */
 - (void)sendPing:(NSData *)data;
 
 @end
 
+///--------------------------------------
 #pragma mark - SRWebSocketDelegate
+///--------------------------------------
 
 @protocol SRWebSocketDelegate <NSObject>
 

--- a/Tests/Operations/SRAutobahnOperation.m
+++ b/Tests/Operations/SRAutobahnOperation.m
@@ -58,7 +58,11 @@ SRAutobahnOperation *SRAutobahnTestOperation(NSURL *serverURL, NSInteger caseNum
                                                caseNumber:@(caseNumber)
                                                     agent:agent
                                            messageHandler:^(SRWebSocket * _Nonnull socket, id  _Nullable message) {
+                                               //TODO: (nlutsenko) Use proper callbacks, instead of a unifying one.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                                                [socket send:message];
+#pragma clang diagnostic pop
                                            }];
 }
 


### PR DESCRIPTION
Both new methods accept `nil` and are sending it as a text frame (the same behavior as before).
The old method is deprecated now, whee!