### PR TITLE
Split 'webSocket:didReceiveMessage:' intro string/data methods.

### DIFF
--- a/SocketRocket/Internal/Delegate/SRDelegateController.h
+++ b/SocketRocket/Internal/Delegate/SRDelegateController.h
@@ -14,6 +14,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 struct SRDelegateAvailableMethods {
+    BOOL didReceiveMessage : 1;
+    BOOL didReceiveMessageWithString : 1;
+    BOOL didReceiveMessageWithData : 1;
     BOOL didOpen : 1;
     BOOL didFailWithError : 1;
     BOOL didCloseWithCode : 1;

--- a/SocketRocket/Internal/Delegate/SRDelegateController.m
+++ b/SocketRocket/Internal/Delegate/SRDelegateController.m
@@ -50,6 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
         _delegate = delegate;
 
         self.availableDelegateMethods = (SRDelegateAvailableMethods){
+            .didReceiveMessage = [delegate respondsToSelector:@selector(webSocket:didReceiveMessage:)],
+            .didReceiveMessageWithString = [delegate respondsToSelector:@selector(webSocket:didReceiveMessageWithString:)],
+            .didReceiveMessageWithData = [delegate respondsToSelector:@selector(webSocket:didReceiveMessageWithData:)],
             .didOpen = [delegate respondsToSelector:@selector(webSocketDidOpen:)],
             .didFailWithError = [delegate respondsToSelector:@selector(webSocket:didFailWithError:)],
             .didCloseWithCode = [delegate respondsToSelector:@selector(webSocket:didCloseWithCode:reason:wasClean:)],

--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -151,11 +151,36 @@ extern NSString *const SRHTTPResponseErrorKey;
 
 @protocol SRWebSocketDelegate <NSObject>
 
-// message will either be an NSString if the server is using text
-// or NSData if the server is using binary.
+@optional
+
+#pragma mark Receive Messages
+
+/**
+ Called when any message was received from a web socket.
+ This method is suboptimal and might be deprecated in a future release.
+
+ @param webSocket An instance of `SRWebSocket` that received a message.
+ @param message   Received message. Either a `String` or `NSData`.
+ */
 - (void)webSocket:(SRWebSocket *)webSocket didReceiveMessage:(id)message;
 
-@optional
+/**
+ Called when a frame was received from a web socket.
+
+ @param webSocket An instance of `SRWebSocket` that received a message.
+ @param string    Received text in a form of UTF-8 `String`.
+ */
+- (void)webSocket:(SRWebSocket *)webSocket didReceiveMessageWithString:(NSString *)string;
+
+/**
+ Called when a frame was received from a web socket.
+
+ @param webSocket An instance of `SRWebSocket` that received a message.
+ @param data      Received data in a form of `NSData`.
+ */
+- (void)webSocket:(SRWebSocket *)webSocket didReceiveMessageWithData:(NSData *)data;
+
+#pragma mark Status & Connection
 
 - (void)webSocketDidOpen:(SRWebSocket *)webSocket;
 - (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error;

--- a/Tests/Operations/SRAutobahnOperation.h
+++ b/Tests/Operations/SRAutobahnOperation.h
@@ -11,7 +11,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void(^SRAutobahnSocketMessageHandler)(SRWebSocket *socket, id _Nullable message);
+typedef void(^SRAutobahnSocketTextMessageHandler)(SRWebSocket *socket, NSString  * _Nullable message);
+typedef void(^SRAutobahnSocketDataMessageHandler)(SRWebSocket *socket, NSData  * _Nullable message);
 
 @interface SRAutobahnOperation : SRTWebSocketOperation
 
@@ -19,14 +20,15 @@ typedef void(^SRAutobahnSocketMessageHandler)(SRWebSocket *socket, id _Nullable 
                   testCommandPath:(NSString *)path
                        caseNumber:(nullable NSNumber *)caseNumber
                             agent:(nullable NSString *)agent
-                   messageHandler:(SRAutobahnSocketMessageHandler)messageHandler;
+               textMessageHandler:(nullable SRAutobahnSocketTextMessageHandler)textMessageHandler
+               dataMessageHandler:(nullable SRAutobahnSocketDataMessageHandler)dataMessageHandler;
 
 @end
 
 extern SRAutobahnOperation *SRAutobahnTestOperation(NSURL *serverURL, NSInteger caseNumber, NSString *agent);
 
 typedef void(^SRAutobahnTestResultHandler)(NSDictionary *_Nullable result);
-extern SRAutobahnOperation *SRAutobahnTestResultOperation(NSURL *serverURL, NSInteger caseNumber, NSString *agent, SRAutobahnTestResultHandler resultHandler);
+extern SRAutobahnOperation *SRAutobahnTestResultOperation(NSURL *serverURL, NSInteger caseNumber, NSString *agent, SRAutobahnTestResultHandler handler);
 
 typedef void(^SRAutobahnTestCaseInfoHandler)(NSDictionary *_Nullable caseInfo);
 extern SRAutobahnOperation *SRAutobahnTestCaseInfoOperation(NSURL *serverURL, NSInteger caseNumber, SRAutobahnTestCaseInfoHandler handler);

--- a/Tests/Operations/SRTWebSocketOperation.m
+++ b/Tests/Operations/SRTWebSocketOperation.m
@@ -65,11 +65,6 @@
     _webSocket = nil;
 }
 
-- (void)webSocket:(SRWebSocket *)webSocket didReceiveMessage:(id)message;
-{
-    NSAssert(NO, @"Not implemented");
-}
-
 - (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error;
 {
     _error = error;


### PR DESCRIPTION
Do not deprecate the old one, but make it optional.
Add 2 new methods and update all tests to use just them.