### PR TITLE
Fix pinned certificates and extract SSL-related things into SRSecurityOptions.

### DIFF
--- a/SocketRocket.xcodeproj/project.pbxproj
+++ b/SocketRocket.xcodeproj/project.pbxproj
@@ -36,6 +36,15 @@
 		8179958C1CE139700084DA37 /* SRDelegateController.m in Sources */ = {isa = PBXBuildFile; fileRef = 817995851CE139700084DA37 /* SRDelegateController.m */; };
 		8179958D1CE139700084DA37 /* SRDelegateController.m in Sources */ = {isa = PBXBuildFile; fileRef = 817995851CE139700084DA37 /* SRDelegateController.m */; };
 		817996801CE184F40084DA37 /* SRAutobahnUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 8179967F1CE184F40084DA37 /* SRAutobahnUtilities.m */; };
+		8186890E1D08D20D004F94C8 /* valid.cer in Resources */ = {isa = PBXBuildFile; fileRef = 8186890D1D08D20D004F94C8 /* valid.cer */; };
+		8186892F1D08EF3C004F94C8 /* SRSecurityOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8186892D1D08EF3C004F94C8 /* SRSecurityOptions.h */; };
+		818689301D08EF3C004F94C8 /* SRSecurityOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8186892D1D08EF3C004F94C8 /* SRSecurityOptions.h */; };
+		818689311D08EF3C004F94C8 /* SRSecurityOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8186892D1D08EF3C004F94C8 /* SRSecurityOptions.h */; };
+		818689321D08EF3C004F94C8 /* SRSecurityOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8186892D1D08EF3C004F94C8 /* SRSecurityOptions.h */; };
+		818689331D08EF3C004F94C8 /* SRSecurityOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8186892E1D08EF3C004F94C8 /* SRSecurityOptions.m */; };
+		818689341D08EF3C004F94C8 /* SRSecurityOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8186892E1D08EF3C004F94C8 /* SRSecurityOptions.m */; };
+		818689351D08EF3C004F94C8 /* SRSecurityOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8186892E1D08EF3C004F94C8 /* SRSecurityOptions.m */; };
+		818689361D08EF3C004F94C8 /* SRSecurityOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8186892E1D08EF3C004F94C8 /* SRSecurityOptions.m */; };
 		81B22EC51CE42D7E0073C636 /* SRError.h in Headers */ = {isa = PBXBuildFile; fileRef = 81B22EC31CE42D7E0073C636 /* SRError.h */; };
 		81B22EC61CE42D7E0073C636 /* SRError.h in Headers */ = {isa = PBXBuildFile; fileRef = 81B22EC31CE42D7E0073C636 /* SRError.h */; };
 		81B22EC71CE42D7E0073C636 /* SRError.h in Headers */ = {isa = PBXBuildFile; fileRef = 81B22EC31CE42D7E0073C636 /* SRError.h */; };
@@ -159,6 +168,9 @@
 		817995851CE139700084DA37 /* SRDelegateController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SRDelegateController.m; sourceTree = "<group>"; };
 		8179967E1CE184F40084DA37 /* SRAutobahnUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SRAutobahnUtilities.h; sourceTree = "<group>"; };
 		8179967F1CE184F40084DA37 /* SRAutobahnUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SRAutobahnUtilities.m; sourceTree = "<group>"; };
+		8186890D1D08D20D004F94C8 /* valid.cer */ = {isa = PBXFileReference; lastKnownFileType = file; name = valid.cer; path = ../../../../Desktop/valid.cer; sourceTree = "<group>"; };
+		8186892D1D08EF3C004F94C8 /* SRSecurityOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SRSecurityOptions.h; sourceTree = "<group>"; };
+		8186892E1D08EF3C004F94C8 /* SRSecurityOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SRSecurityOptions.m; sourceTree = "<group>"; };
 		81B22EC31CE42D7E0073C636 /* SRError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SRError.h; sourceTree = "<group>"; };
 		81B22EC41CE42D7E0073C636 /* SRError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SRError.m; sourceTree = "<group>"; };
 		81B22EE21CE43ECC0073C636 /* SRURLUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SRURLUtilities.h; sourceTree = "<group>"; };
@@ -342,9 +354,19 @@
 			path = Delegate;
 			sourceTree = "<group>";
 		};
+		8186892C1D08EF3C004F94C8 /* Security */ = {
+			isa = PBXGroup;
+			children = (
+				8186892D1D08EF3C004F94C8 /* SRSecurityOptions.h */,
+				8186892E1D08EF3C004F94C8 /* SRSecurityOptions.m */,
+			);
+			path = Security;
+			sourceTree = "<group>";
+		};
 		81B31C0D1CDC404100D86D43 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
+				8186892C1D08EF3C004F94C8 /* Security */,
 				4861E7721D022211002FAB1D /* Proxy */,
 				817995831CE139540084DA37 /* Delegate */,
 				81B31C0E1CDC404100D86D43 /* IOConsumer */,
@@ -394,6 +416,7 @@
 				F62417EB14D52F3C003CE997 /* Supporting Files */,
 				F62417F314D52F3C003CE997 /* TCAppDelegate.h */,
 				F62417F414D52F3C003CE997 /* TCAppDelegate.m */,
+				8186890D1D08D20D004F94C8 /* valid.cer */,
 				F62417F614D52F3C003CE997 /* MainStoryboard.storyboard */,
 				F62417F914D52F3C003CE997 /* TCViewController.h */,
 				F62417FA14D52F3C003CE997 /* TCViewController.m */,
@@ -503,6 +526,7 @@
 				81CD05FE1CEEC65D00497F47 /* NSRunLoop+SRWebSocket.h in Headers */,
 				81CD05D81CEEC47300497F47 /* NSURLRequest+SRWebSocket.h in Headers */,
 				81B31C1D1CDC404100D86D43 /* SRIOConsumerPool.h in Headers */,
+				818689301D08EF3C004F94C8 /* SRSecurityOptions.h in Headers */,
 				2D42277F1BB4365C000C1A6C /* SRWebSocket.h in Headers */,
 				81B31C2E1CDC406B00D86D43 /* SRHash.h in Headers */,
 				811934BE1CDAF725003AB243 /* SocketRocket.h in Headers */,
@@ -521,6 +545,7 @@
 				81CD06001CEEC65D00497F47 /* NSRunLoop+SRWebSocket.h in Headers */,
 				81CD05DA1CEEC47300497F47 /* NSURLRequest+SRWebSocket.h in Headers */,
 				81B31C1F1CDC404100D86D43 /* SRIOConsumerPool.h in Headers */,
+				818689321D08EF3C004F94C8 /* SRSecurityOptions.h in Headers */,
 				3345DC8A1C52ACD70083CCB8 /* SRWebSocket.h in Headers */,
 				81B31C301CDC406B00D86D43 /* SRHash.h in Headers */,
 				811934C01CDAF726003AB243 /* SocketRocket.h in Headers */,
@@ -539,6 +564,7 @@
 				81CD05FF1CEEC65D00497F47 /* NSRunLoop+SRWebSocket.h in Headers */,
 				81CD05D91CEEC47300497F47 /* NSURLRequest+SRWebSocket.h in Headers */,
 				81B31C1E1CDC404100D86D43 /* SRIOConsumerPool.h in Headers */,
+				818689311D08EF3C004F94C8 /* SRSecurityOptions.h in Headers */,
 				F668C8AA153E92F90044DBAC /* SRWebSocket.h in Headers */,
 				81B31C2F1CDC406B00D86D43 /* SRHash.h in Headers */,
 				811934BC1CDAF725003AB243 /* SocketRocket.h in Headers */,
@@ -556,6 +582,7 @@
 				81B31C141CDC404100D86D43 /* SRIOConsumer.h in Headers */,
 				81CD05FD1CEEC65D00497F47 /* NSRunLoop+SRWebSocket.h in Headers */,
 				81CD05D71CEEC47300497F47 /* NSURLRequest+SRWebSocket.h in Headers */,
+				8186892F1D08EF3C004F94C8 /* SRSecurityOptions.h in Headers */,
 				81B31C1C1CDC404100D86D43 /* SRIOConsumerPool.h in Headers */,
 				F6A12CD1145119B700C1D980 /* SRWebSocket.h in Headers */,
 				81B31C2D1CDC406B00D86D43 /* SRHash.h in Headers */,
@@ -727,6 +754,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F62417EF14D52F3C003CE997 /* InfoPlist.strings in Resources */,
+				8186890E1D08D20D004F94C8 /* valid.cer in Resources */,
 				F62417F814D52F3C003CE997 /* MainStoryboard.storyboard in Resources */,
 				F61A0DC81625F44D00365EBD /* Default-568h@2x.png in Resources */,
 			);
@@ -757,6 +785,7 @@
 				81CD05DC1CEEC47300497F47 /* NSURLRequest+SRWebSocket.m in Sources */,
 				81B22ECA1CE42D7E0073C636 /* SRError.m in Sources */,
 				81B31C191CDC404100D86D43 /* SRIOConsumer.m in Sources */,
+				818689341D08EF3C004F94C8 /* SRSecurityOptions.m in Sources */,
 				81CD06021CEEC65D00497F47 /* NSRunLoop+SRWebSocket.m in Sources */,
 				2D4227851BB43734000C1A6C /* SRWebSocket.m in Sources */,
 				81B31C211CDC404100D86D43 /* SRIOConsumerPool.m in Sources */,
@@ -774,6 +803,7 @@
 				81CD05DE1CEEC47300497F47 /* NSURLRequest+SRWebSocket.m in Sources */,
 				81B22ECC1CE42D7E0073C636 /* SRError.m in Sources */,
 				81B31C1B1CDC404100D86D43 /* SRIOConsumer.m in Sources */,
+				818689361D08EF3C004F94C8 /* SRSecurityOptions.m in Sources */,
 				81CD06041CEEC65D00497F47 /* NSRunLoop+SRWebSocket.m in Sources */,
 				3345DC841C52ACD70083CCB8 /* SRWebSocket.m in Sources */,
 				81B31C231CDC404100D86D43 /* SRIOConsumerPool.m in Sources */,
@@ -802,6 +832,7 @@
 				81CD05DD1CEEC47300497F47 /* NSURLRequest+SRWebSocket.m in Sources */,
 				81B22ECB1CE42D7E0073C636 /* SRError.m in Sources */,
 				81B31C1A1CDC404100D86D43 /* SRIOConsumer.m in Sources */,
+				818689351D08EF3C004F94C8 /* SRSecurityOptions.m in Sources */,
 				81CD06031CEEC65D00497F47 /* NSRunLoop+SRWebSocket.m in Sources */,
 				F6396B86153E67EC00345B5E /* SRWebSocket.m in Sources */,
 				81B31C221CDC404100D86D43 /* SRIOConsumerPool.m in Sources */,
@@ -817,6 +848,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4861E7761D022211002FAB1D /* SRProxyConnect.m in Sources */,
+				818689331D08EF3C004F94C8 /* SRSecurityOptions.m in Sources */,
 				81CD05DB1CEEC47300497F47 /* NSURLRequest+SRWebSocket.m in Sources */,
 				81B22EC91CE42D7E0073C636 /* SRError.m in Sources */,
 				81B31C181CDC404100D86D43 /* SRIOConsumer.m in Sources */,

--- a/SocketRocket/Internal/Security/SRSecurityOptions.h
+++ b/SocketRocket/Internal/Security/SRSecurityOptions.h
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SRSecurityOptions: NSObject
+
+@property (nonatomic, strong, readonly) NSURLRequest *request;
+
+/**
+ Returns `YES` if request uses SSL, otherwise - `NO`.
+ */
+@property (nonatomic, assign, readonly) BOOL requestRequiresSSL;
+
+/**
+ Optional array of `SecCertificateRef` SSL certificates to use for validation.
+ */
+@property (nullable, nonatomic, strong, readonly) NSArray *pinnedCertificates;
+
+/**
+ Set to `NO` to disable SSL certificate chain validation.
+ This option is not taken into account when using pinned certificates.
+ Default: YES.
+ */
+@property (nonatomic, assign, readonly) BOOL validatesCertificateChain;
+
+/**
+ Initializes an instance of a controller into it with a given request and returns it.
+
+ @param request Request to initialize with.
+ */
+- (instancetype)initWithRequest:(NSURLRequest *)request
+             pinnedCertificates:(nullable NSArray *)pinnedCertificates
+         chainValidationEnabled:(BOOL)chainValidationEnabled NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+///--------------------------------------
+#pragma mark - Streams
+///--------------------------------------
+
+/**
+ Updates all the security options for the current configuration.
+
+ @param stream Stream to update the options in.
+ */
+- (void)updateSecurityOptionsInStream:(NSStream *)stream;
+
+///--------------------------------------
+#pragma mark - Pinned Certificates
+///--------------------------------------
+
+/**
+ Validates whether a given security trust contains pinned certificates.
+ If no certificates are pinned - returns `YES`.
+
+ @param trust Security trust to validate.
+
+ @return `YES` if certificates where found, otherwise - `NO`.
+ */
+- (BOOL)securityTrustContainsPinnedCertificates:(SecTrustRef)trust;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SocketRocket/Internal/Security/SRSecurityOptions.m
+++ b/SocketRocket/Internal/Security/SRSecurityOptions.m
@@ -1,0 +1,88 @@
+//
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+//
+
+#import "SRSecurityOptions.h"
+
+#import "SRURLUtilities.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation SRSecurityOptions
+
+///--------------------------------------
+#pragma mark - Init
+///--------------------------------------
+
+- (instancetype)initWithRequest:(NSURLRequest *)request
+             pinnedCertificates:(nullable NSArray *)pinnedCertificates
+         chainValidationEnabled:(BOOL)chainValidationEnabled
+{
+    self = [super init];
+    if (!self) return self;
+
+    _request = request;
+    _requestRequiresSSL = SRURLRequiresSSL(request.URL);
+    _pinnedCertificates = pinnedCertificates;
+    _validatesCertificateChain = chainValidationEnabled;
+
+    return self;
+}
+
+///--------------------------------------
+#pragma mark - Stream
+///---------------------------------------
+
+- (void)updateSecurityOptionsInStream:(NSStream *)stream
+{
+    // SSL not required, skip everything
+    if (!self.requestRequiresSSL) {
+        return;
+    }
+
+    // Enable highest level of security (`.LevelNegotiatedSSL`) for the stream.
+    [stream setProperty:NSStreamSocketSecurityLevelNegotiatedSSL forKey:NSStreamSocketSecurityLevelKey];
+
+    // If we are not using pinned certs and if chain validation is enabled - enable it on a stream.
+    BOOL chainValidationEnabled = (_pinnedCertificates.count == 0 && self.validatesCertificateChain);
+    NSDictionary<NSString *, id> *sslOptions = @{ (__bridge NSString *)kCFStreamSSLValidatesCertificateChain : @(chainValidationEnabled) };
+    [stream setProperty:sslOptions forKey:(__bridge NSString *)kCFStreamPropertySSLSettings];
+}
+
+///--------------------------------------
+#pragma mark - Pinned Certificates
+///--------------------------------------
+
+- (BOOL)securityTrustContainsPinnedCertificates:(SecTrustRef)trust
+{
+    NSUInteger requiredCertCount = self.pinnedCertificates.count;
+    if (requiredCertCount == 0) {
+        return YES;
+    }
+
+    NSUInteger validatedCertCount = 0;
+    CFIndex serverCertCount = SecTrustGetCertificateCount(trust);
+    for (CFIndex i = 0; i < serverCertCount; i++) {
+        SecCertificateRef cert = SecTrustGetCertificateAtIndex(trust, i);
+        NSData *data = CFBridgingRelease(SecCertificateCopyData(cert));
+        for (id ref in self.pinnedCertificates) {
+            SecCertificateRef trustedCert = (__bridge SecCertificateRef)ref;
+            // TODO: (nlutsenko) Add caching, so we don't copy the data for every pinned cert all the time.
+            NSData *trustedCertData = CFBridgingRelease(SecCertificateCopyData(trustedCert));
+            if ([trustedCertData isEqualToData:data]) {
+                validatedCertCount++;
+                break;
+            }
+        }
+    }
+    return (requiredCertCount == validatedCertCount);
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
The fix is trivial - we were calling into `didConnect` twice, but if SSL is enabled - we should only call into it after the validation finishes.
The refactoring here should help with reusing code as well as encapsulating it together.

Validates that the fix actually works and security is still there by running against `wss://echo.websocket.org` and `ws://echo.websocket.org` with these options:
- No pinned cert (SSL: on)
- No pinned cert (SSL: off)
- Pinned single cert from the chain of `*.websocket.org`
- Pinned multi cert from the chain of `*.websocket.org`
- Pinned wrong cert (actually just used `Apple WWDR` which is a valid one but is not in the chain)
- Pinned valid and wrong cert (one from `*.websocket.org` and `Apple WWDR`)

Everything looks good and we properly bail-out as soon as we detect that something doesn't validate.

Fixes #402.