### PR TITLE
Fix compilation warnings when building with Xcode 8.

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -351,7 +351,10 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Host"), (__bridge CFStringRef)(_url.port ? [NSString stringWithFormat:@"%@:%@", _url.host, _url.port] : _url.host));
 
     NSMutableData *keyBytes = [[NSMutableData alloc] initWithLength:16];
-    SecRandomCopyBytes(kSecRandomDefault, keyBytes.length, keyBytes.mutableBytes);
+    int result = SecRandomCopyBytes(kSecRandomDefault, keyBytes.length, keyBytes.mutableBytes);
+    if (result != 0) {
+        //TODO: (nlutsenko) Check if there was an error.
+    }
 
     if ([keyBytes respondsToSelector:@selector(base64EncodedStringWithOptions:)]) {
         _secKey = [keyBytes base64EncodedStringWithOptions:0];
@@ -1360,7 +1363,11 @@ static const size_t SRFrameHeaderOverhead = 32;
         }
     } else {
         uint8_t *mask_key = frame_buffer + frame_buffer_size;
-        SecRandomCopyBytes(kSecRandomDefault, sizeof(uint32_t), (uint8_t *)mask_key);
+        int result = SecRandomCopyBytes(kSecRandomDefault, sizeof(uint32_t), (uint8_t *)mask_key);
+        if (result != 0) {
+            //TODO: (nlutsenko) Check if there was an error.
+        }
+
         frame_buffer_size += sizeof(uint32_t);
 
         // TODO: could probably optimize this with SIMD


### PR DESCRIPTION
Looks like there is `warn_unused_result` attribute on these now.