### PR TITLE
Fix crash on SRProxyConnect deallocation, when timeout was encountered.

### DIFF
--- a/SocketRocket/Internal/Proxy/SRProxyConnect.m
+++ b/SocketRocket/Internal/Proxy/SRProxyConnect.m
@@ -113,6 +113,10 @@ static inline void SRProxyFastLog(NSString *format, ...);
         CFRelease(_receivedHTTPHeaders);
         _receivedHTTPHeaders = NULL;
     }
+
+    self.inputStream.delegate = nil;
+    self.outputStream.delegate = nil;
+
     [self.inputStream removeFromRunLoop:[NSRunLoop SR_networkRunLoop]
                                 forMode:NSDefaultRunLoopMode];
     [self.inputStream close];

--- a/SocketRocket/Internal/Proxy/SRProxyConnect.m
+++ b/SocketRocket/Internal/Proxy/SRProxyConnect.m
@@ -60,6 +60,20 @@ static inline void SRProxyFastLog(NSString *format, ...);
     return self;
 }
 
+- (void)dealloc
+{
+    // If we get deallocated before the socket open finishes - we need to cleanup everything.
+
+    [self.inputStream removeFromRunLoop:[NSRunLoop SR_networkRunLoop] forMode:NSDefaultRunLoopMode];
+    self.inputStream.delegate = nil;
+    [self.inputStream close];
+    self.inputStream = nil;
+
+    self.outputStream.delegate = nil;
+    [self.outputStream close];
+    self.outputStream = nil;
+}
+
 ///--------------------------------------
 #pragma mark - Open
 ///--------------------------------------


### PR DESCRIPTION
Looks like there is a potential ability for `SRProxyConnect` to be deallocated before the streams are off-loaded to `SRWebSocket`.
Thus, remove the delegates, close and cleanup the streams in dealloc, which will be a no-op in fail/success inside `SRProxyConnect` as we reset everything back to `nil`.

Fixes #400