### PR TITLE
Use error pointers instead of asserts for validating status on send:.

### DIFF
--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -237,28 +237,43 @@ NS_DESIGNATED_INITIALIZER;
 
  @deprecated Please use `sendString:` or `sendData` instead.
  */
-- (void)send:(nullable id)message __attribute__((deprecated("Please use `sendString:` or `sendData` instead.")));
+- (void)send:(nullable id)message __attribute__((deprecated("Please use `sendString:error:` or `sendData:error:` instead.")));
 
 /**
  Send a UTF-8 String to the server.
 
  @param string String to send.
+ @param error  On input, a pointer to variable for an `NSError` object.
+ If an error occurs, this pointer is set to an `NSError` object containing information about the error.
+ You may specify `nil` to ignore the error information.
+
+ @return `YES` if the string was scheduled to send, otherwise - `NO`.
  */
-- (void)sendString:(NSString *)string;
+- (BOOL)sendString:(NSString *)string error:(NSError **)error NS_SWIFT_NAME(send(string:));
 
 /**
  Send binary data to the server.
 
- @param data Data to send.
+ @param data  Data to send.
+ @param error On input, a pointer to variable for an `NSError` object.
+ If an error occurs, this pointer is set to an `NSError` object containing information about the error.
+ You may specify `nil` to ignore the error information.
+
+ @return `YES` if the string was scheduled to send, otherwise - `NO`.
  */
-- (void)sendData:(nullable NSData *)data;
+- (BOOL)sendData:(nullable NSData *)data error:(NSError **)error NS_SWIFT_NAME(send(data:));
 
 /**
  Send Ping message to the server with optional data.
 
- @param data Instance of `NSData` or `nil`.
+ @param data  Instance of `NSData` or `nil`.
+ @param error On input, a pointer to variable for an `NSError` object.
+ If an error occurs, this pointer is set to an `NSError` object containing information about the error.
+ You may specify `nil` to ignore the error information.
+
+ @return `YES` if the string was scheduled to send, otherwise - `NO`.
  */
-- (void)sendPing:(nullable NSData *)data;
+- (BOOL)sendPing:(nullable NSData *)data error:(NSError **)error NS_SWIFT_NAME(sendPing(_:));
 
 @end
 

--- a/Tests/Operations/SRAutobahnOperation.m
+++ b/Tests/Operations/SRAutobahnOperation.m
@@ -70,10 +70,10 @@ SRAutobahnOperation *SRAutobahnTestOperation(NSURL *serverURL, NSInteger caseNum
                                                caseNumber:@(caseNumber)
                                                     agent:agent
                                        textMessageHandler:^(SRWebSocket * _Nonnull socket, NSString  * _Nullable message) {
-                                           [socket sendString:message];
+                                           [socket sendString:message error:nil];
                                        }
                                        dataMessageHandler:^(SRWebSocket * _Nonnull socket, NSData * _Nullable message) {
-                                           [socket sendData:message];
+                                           [socket sendData:message error:nil];
                                        }];
 }
 


### PR DESCRIPTION
Remove asserts and replace all of them with pointer to a pointer to `NSError`, which is imported into Swift with a nice `throws` syntax.
This also going to validate whether a socket is fully open, instead of validating on `conecting` only.

Depends on #417.
Fixes #206.
Fixes #54.