### PR TITLE
Ensure test environment is ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,19 +7,23 @@ all:
 clean:
 	$(MAKE) -C SocketRocket clean
 
-test:
+.env:
+
+	./TestSupport/setup_env.sh .env
+
+test: .env
 
 	mkdir -p pages/results
 	bash ./TestSupport/run_test_server.sh $(TEST_SCENARIOS) $(TEST_URL) Debug || open pages/results/index.html && false
 	open pages/results/index.html
 
-test_all:
+test_all: .env
 
 	mkdir -p pages/results
 	bash ./TestSupport/run_test_server.sh '*' $(TEST_URL) Debug || open pages/results/index.html && false
 	open pages/results/index.html
 
-test_perf:
+test_perf: .env
 
 	mkdir -p pages/results
 	bash ./TestSupport/run_test_server.sh '9.*' $(TEST_URL) Release || open pages/results/index.html && false


### PR DESCRIPTION
When running tests, this makes sure that the test environment is ready to go.  This possibly fixes https://github.com/facebook/SocketRocket/issues/388.
