### PR TITLE
Fix memory leak by freeing mutex.

### DIFF
--- a/SocketRocket/Internal/Utilities/SRMutex.m
+++ b/SocketRocket/Internal/Utilities/SRMutex.m
@@ -29,6 +29,7 @@ SRMutex SRMutexInitRecursive(void)
 void SRMutexDestroy(SRMutex mutex)
 {
     pthread_mutex_destroy(mutex);
+    free(mutex);
 }
 
 __attribute__((no_thread_safety_analysis))


### PR DESCRIPTION
Instruments shows a leak of category Malloc 64 Bytes from `SRMutexInitRecursive` after re-initializing a `SRWebSocket` property.

I have an app that uses a `SRWebSocket` property for a few different subscriptions that need to be active at different times. As a temporary solution I am manually closing the socket to unsubscribe from everything and re-initializing the socket since I can only call `open` on each instance once.

After calling `free` on mutex, the memory leak no longer appears in Instruments.