### PR TITLE
Fixes debug logging

### DIFF
--- a/SocketRocket/Internal/Proxy/SRProxyConnect.m
+++ b/SocketRocket/Internal/Proxy/SRProxyConnect.m
@@ -337,7 +337,7 @@
 
 - (void)stream:(NSStream *)aStream handleEvent:(NSStreamEvent)eventCode;
 {
-    SRDebugLog(@"stream handleEvent %u", eventCode);
+    SRDebugLog(@"stream handleEvent %lu", (unsigned long)eventCode);
     switch (eventCode) {
         case NSStreamEventOpenCompleted: {
             if (aStream == self.inputStream) {
@@ -437,14 +437,14 @@
     NSInteger responseCode = CFHTTPMessageGetResponseStatusCode(_receivedHTTPHeaders);
 
     if (responseCode >= 299) {
-        SRDebugLog(@"Connect to Proxy Request failed with response code %d", responseCode);
+        SRDebugLog(@"Connect to Proxy Request failed with response code %ld", (long)responseCode);
         NSError *error = SRHTTPErrorWithCodeDescription(responseCode, 2132,
                                                         [NSString stringWithFormat:@"Received bad response code from proxy server: %d.",
                                                          (int)responseCode]);
         [self _failWithError:error];
         return;
     }
-    SRDebugLog(@"proxy connect return %d, call socket connect", responseCode);
+    SRDebugLog(@"proxy connect return %ld, call socket connect", (long)responseCode);
     [self _didConnect];
 }
 

--- a/SocketRocket/Internal/Security/SRPinningSecurityPolicy.m
+++ b/SocketRocket/Internal/Security/SRPinningSecurityPolicy.m
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)evaluateServerTrust:(SecTrustRef)serverTrust forDomain:(NSString *)domain
 {
-    SRDebugLog(@"Pinned cert count: %d", self.pinnedCertificates.count);
+    SRDebugLog(@"Pinned cert count: %lu", (unsigned long)self.pinnedCertificates.count);
     NSUInteger requiredCertCount = self.pinnedCertificates.count;
 
     NSUInteger validatedCertCount = 0;

--- a/SocketRocket/Internal/Utilities/SRLog.h
+++ b/SocketRocket/Internal/Utilities/SRLog.h
@@ -15,6 +15,11 @@ NS_ASSUME_NONNULL_BEGIN
 //#define SR_DEBUG_LOG_ENABLED
 
 extern void SRErrorLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2);
-extern void SRDebugLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2);
+
+#ifdef SR_DEBUG_LOG_ENABLED
+    #define SRDebugLog(format, ...) SRErrorLog(format, ##__VA_ARGS__)
+#else
+    #define SRDebugLog(format, ...) {}
+#endif
 
 NS_ASSUME_NONNULL_END

--- a/SocketRocket/Internal/Utilities/SRLog.h
+++ b/SocketRocket/Internal/Utilities/SRLog.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 // Uncomment this line to enable debug logging
 //#define SR_DEBUG_LOG_ENABLED
 
-extern void SRErrorLog(NSString *format, ...);
-extern void SRDebugLog(NSString *format, ...);
+extern void SRErrorLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2);
+extern void SRDebugLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2);
 
 NS_ASSUME_NONNULL_END

--- a/SocketRocket/Internal/Utilities/SRLog.m
+++ b/SocketRocket/Internal/Utilities/SRLog.m
@@ -23,11 +23,4 @@ extern void SRErrorLog(NSString *format, ...)
     NSLog(@"[SocketRocket] %@", formattedString);
 }
 
-extern void SRDebugLog(NSString *format, ...)
-{
-#ifdef SR_DEBUG_LOG_ENABLED
-    SRErrorLog(tag, format);
-#endif
-}
-
 NS_ASSUME_NONNULL_END

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -373,7 +373,7 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
 {
     NSInteger responseCode = CFHTTPMessageGetResponseStatusCode(_receivedHTTPHeaders);
     if (responseCode >= 400) {
-        SRDebugLog(@"Request failed with response code %d", responseCode);
+        SRDebugLog(@"Request failed with response code %ld", (long)responseCode);
         NSError *error = SRHTTPErrorWithCodeDescription(responseCode, 2132,
                                                         [NSString stringWithFormat:@"Received bad response code from server: %d.",
                                                          (int)responseCode]);
@@ -411,7 +411,6 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
         }
     }];
 }
-
 
 - (void)_readHTTPHeader;
 {
@@ -500,7 +499,7 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
 
         self.readyState = SR_CLOSING;
 
-        SRDebugLog(@"Closing with code %d reason %@", code, reason);
+        SRDebugLog(@"Closing with code %ld reason %@", (long)code, reason);
 
         if (wasConnecting) {
             [self closeConnection];
@@ -602,7 +601,7 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
         if (error) {
             *error = SRErrorWithCodeDescription(2134, message);
         }
-        SRDebugLog(message);
+        SRDebugLog(@"%@", message);
         return NO;
     }
 
@@ -626,7 +625,7 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
         if (error) {
             *error = SRErrorWithCodeDescription(2134, message);
         }
-        SRDebugLog(message);
+        SRDebugLog(@"%@", message);
         return NO;
     }
 
@@ -647,7 +646,7 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
         if (error) {
             *error = SRErrorWithCodeDescription(2134, message);
         }
-        SRDebugLog(message);
+        SRDebugLog(@"%@", message);
         return NO;
     }
 

--- a/Tests/SRAutobahnTests.m
+++ b/Tests/SRAutobahnTests.m
@@ -137,7 +137,7 @@
 
 
     XCTAssertTrue([resultOp waitUntilFinishedWithTimeout:60 * 5], @"Test operation timed out.");
-    XCTAssertTrue(!testOp.error, @"Test operation should not have failed");
+    XCTAssertTrue(!testOp.error, @"Test operation should not have failed: %@", testOp.error);
     if (!SRAutobahnIsValidResultBehavior(identifier, resultInfo[@"behavior"])) {
         XCTFail(@"Invalid test behavior %@ for %@.", resultInfo[@"behavior"], identifier);
     }


### PR DESCRIPTION
It looks like `SRDebugLog` hasn't been used a in a while because uncommenting `#define SR_DEBUG_LOG_ENABLED` caused a bunch of compiler errors.

This change fixes up the use of `SRDebugLog` so that uncommenting `#define SR_DEBUG_LOG_ENABLED` will properly emit log statements.

Additionally, I added the `NS_FORMAT` attribute to `SRErrorLog`, which hints to the compiler that `SRErrorLog` has a format string parameter.  This caused a few analyzer warnings that this PR also fixes.