### PR TITLE
Fix memory leaks

### DIFF
--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -85,7 +85,7 @@ extern NSString *const SRHTTPResponseErrorKey;
 /**
  An operation queue for scheduling the delegate calls.
 
- If `nil` and `delegateOperationQueue` is `nil`, the socket uses main queue for performing all delegate method calls.
+ If `nil` and `delegateDispatchQueue` is `nil`, the socket uses main queue for performing all delegate method calls.
  */
 @property (nullable, nonatomic, strong) NSOperationQueue *delegateOperationQueue;
 

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -165,7 +165,7 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
     _workQueue = dispatch_queue_create(NULL, DISPATCH_QUEUE_SERIAL);
 
     // Going to set a specific on the queue so we can validate we're on the work queue
-    dispatch_queue_set_specific(_workQueue, (__bridge void *)self, (__bridge void *)(_workQueue), NULL);
+    dispatch_queue_set_specific(_workQueue, (__bridge void *)(_workQueue), (__bridge void *)(_workQueue), NULL);
 
     _delegateController = [[SRDelegateController alloc] init];
 
@@ -236,7 +236,7 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
 
 - (void)assertOnWorkQueue;
 {
-    assert(dispatch_get_specific((__bridge void *)self) == (__bridge void *)_workQueue);
+    assert(dispatch_get_specific((__bridge void *)(_workQueue)) == (__bridge void *)_workQueue);
 }
 
 ///--------------------------------------


### PR DESCRIPTION
I believe this PR fixes #499 and addresses a few more memory related issues I found.  

The root cause of #499 was that the timeout timer was strongly retaining the `SRWebSocket` instance and wouldn't release it until after the timer popped.

I did find a bonafide memory leak, if you attempted to close the `SRWebSocket` before `SRProxy` had a chance to return, the the `SRWebSocket` would never clean up its strong reference to itself and the object would be trapped in memory forever.