### PR TITLE
Handle IPv6 host in Request Headers

### DIFF
--- a/SocketRocket/Internal/Utilities/SRHTTPConnectMessage.m
+++ b/SocketRocket/Internal/Utilities/SRHTTPConnectMessage.m
@@ -16,7 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString *_SRHTTPConnectMessageHost(NSURL *url)
 {
     NSString *host = url.host;
-    if (url.port) {
+    if ([host containsString:@":"]) {
+        host = [NSString stringWithFormat:@"[%@]:%@", host, url.port];
+    } else {
         host = [host stringByAppendingFormat:@":%@", url.port];
     }
     return host;

--- a/SocketRocket/Internal/Utilities/SRURLUtilities.m
+++ b/SocketRocket/Internal/Utilities/SRURLUtilities.m
@@ -23,7 +23,13 @@ NSString *SRURLOrigin(NSURL *url)
     } else if ([scheme isEqualToString:@"ws"]) {
         scheme = @"http";
     }
-    [origin appendFormat:@"%@://%@", scheme, url.host];
+
+    NSString * host = url.host;
+    if ([host containsString:@":"]) {
+        host = [NSString stringWithFormat:@"[%@]", host];
+    }
+
+    [origin appendFormat:@"%@://%@", scheme, host];
 
     NSNumber *port = url.port;
     BOOL portIsDefault = (!port ||


### PR DESCRIPTION
In case of IPv6 wrap the ip in brackets for "Host" and "Origin" headers
Without the brackets server responds with 400-Bad Request.