### PR TITLE
Fix crash on mac (and 32-bit iOS?) - don't represent SRDelegateAvailableMethods as a bitfield

### DIFF
--- a/SocketRocket/Internal/Delegate/SRDelegateController.h
+++ b/SocketRocket/Internal/Delegate/SRDelegateController.h
@@ -14,15 +14,15 @@
 NS_ASSUME_NONNULL_BEGIN
 
 struct SRDelegateAvailableMethods {
-    BOOL didReceiveMessage : 1;
-    BOOL didReceiveMessageWithString : 1;
-    BOOL didReceiveMessageWithData : 1;
-    BOOL didOpen : 1;
-    BOOL didFailWithError : 1;
-    BOOL didCloseWithCode : 1;
-    BOOL didReceivePing : 1;
-    BOOL didReceivePong : 1;
-    BOOL shouldConvertTextFrameToString : 1;
+    BOOL didReceiveMessage;
+    BOOL didReceiveMessageWithString;
+    BOOL didReceiveMessageWithData;
+    BOOL didOpen;
+    BOOL didFailWithError;
+    BOOL didCloseWithCode;
+    BOOL didReceivePing;
+    BOOL didReceivePong;
+    BOOL shouldConvertTextFrameToString;
 };
 typedef struct SRDelegateAvailableMethods SRDelegateAvailableMethods;
 

--- a/SocketRocket/Internal/Delegate/SRDelegateController.h
+++ b/SocketRocket/Internal/Delegate/SRDelegateController.h
@@ -13,6 +13,22 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if OBJC_BOOL_IS_BOOL
+
+struct SRDelegateAvailableMethods {
+    BOOL didReceiveMessage : 1;
+    BOOL didReceiveMessageWithString : 1;
+    BOOL didReceiveMessageWithData : 1;
+    BOOL didOpen : 1;
+    BOOL didFailWithError : 1;
+    BOOL didCloseWithCode : 1;
+    BOOL didReceivePing : 1;
+    BOOL didReceivePong : 1;
+    BOOL shouldConvertTextFrameToString : 1;
+};
+
+#else
+
 struct SRDelegateAvailableMethods {
     BOOL didReceiveMessage;
     BOOL didReceiveMessageWithString;
@@ -24,6 +40,9 @@ struct SRDelegateAvailableMethods {
     BOOL didReceivePong;
     BOOL shouldConvertTextFrameToString;
 };
+
+#endif
+
 typedef struct SRDelegateAvailableMethods SRDelegateAvailableMethods;
 
 typedef void(^SRDelegateBlock)(id<SRWebSocketDelegate> _Nullable delegate, SRDelegateAvailableMethods availableMethods);


### PR DESCRIPTION
Since Objective-C uses a `signed char` for `BOOL` on some platforms (macOS and I think 32-bit iOS?) representing this struct of BOOLs as 1 bit widths doesn't work since when it tries to read the field it looks for the sign bit and 💥 with an EXC_BAD_INSTRUCTION. This change just removes the width declaration on the struct fields, sacrificing a few bits for the extra portability.

**Alternatives Considered**

1. Alternatively the struct could switch to using two bits:
```
struct SRDelegateAvailableMethods {
    BOOL didReceiveMessage : 2;
    BOOL didReceiveMessageWithString : 2;
    // ...
```
But while this worked in my limited testing, I wasn't sure if would cause other issues, and seemed like just storing the BOOL as-is was safest/most portable.

2.  Or even just use C99 `bool`s, but this doesn't seem great since you're relying on a lot of `BOOL` -> `bool` conversions since `respondsToSelector` etc.. return `BOOL`