### PR TITLE
Add specific bundle version

### DIFF
--- a/SocketRocket/Resources/Info.plist
+++ b/SocketRocket/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>0.5.1</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
When adding SocketRocket as a dependency via Carthage everything works fine, until you submit the app to the App Store. 
When you do you hit this validation error.

![screen shot 2018-02-26 at 10 42 05](https://user-images.githubusercontent.com/348355/36663405-c3f5be42-1ae1-11e8-9baf-b6880647c50d.png)

This PR fixes this error.