### PR TITLE
Bugifx/fix init with url request apple reject

### DIFF
--- a/SocketRocket.xcodeproj/project.pbxproj
+++ b/SocketRocket.xcodeproj/project.pbxproj
@@ -1207,6 +1207,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 81D6475A1D2CA6A100690609 /* SocketRocket-iOS.xcconfig */;
 			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1.0;
+				DYLIB_CURRENT_VERSION = 1.0;
 			};
 			name = Debug;
 		};
@@ -1214,6 +1216,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 81D6475A1D2CA6A100690609 /* SocketRocket-iOS.xcconfig */;
 			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1.0;
+				DYLIB_CURRENT_VERSION = 1.0;
 			};
 			name = Release;
 		};

--- a/SocketRocket/SRWebSocket.h
+++ b/SocketRocket/SRWebSocket.h
@@ -131,7 +131,7 @@ extern NSString *const SRHTTPResponseErrorKey;
 
  @param request Request to initialize with.
  */
-- (instancetype)initWithURLRequest:(NSURLRequest *)request;
+- (instancetype)initWithSRURLRequest:(NSURLRequest *)request;
 
 /**
  Initializes a web socket with a given `NSURLRequest`, specifying a transport security policy (e.g. SSL configuration).

--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -213,7 +213,7 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
 #pragma clang diagnostic pop
 }
 
-- (instancetype)initWithURLRequest:(NSURLRequest *)request
+- (instancetype)initWithSRURLRequest:(NSURLRequest *)request
 {
     return [self initWithURLRequest:request protocols:nil];
 }


### PR DESCRIPTION
Fix problem with ITC processing reject issue:
Non-public API usage: 
• The app references non-public selectors in SocketRocket: initWithURLRequest:
If method names in your source code match the private Apple APIs listed above, altering your method names will help prevent this app from being flagged in future submissions. In addition, note that one or more of the above APIs may be located in a static library that was included with your app. If so, they must be removed.