### PR TITLE
fix the data race about 'readyState'

### DIFF
--- a/SocketRocket/SRWebSocket.m
+++ b/SocketRocket/SRWebSocket.m
@@ -319,7 +319,7 @@ NSString *const SRHTTPResponseErrorKey = @"HTTPResponseStatusCode";
 
     if (_urlRequest.timeoutInterval > 0) {
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(_urlRequest.timeoutInterval * NSEC_PER_SEC));
-        dispatch_after(popTime, dispatch_get_main_queue(), ^{
+        dispatch_after(popTime, _workQueue, ^{
             if (self.readyState == SR_CONNECTING) {
                 NSError *error = SRErrorWithDomainCodeDescription(NSURLErrorDomain, NSURLErrorTimedOut, @"Timed out connecting to server.");
                 [self _failWithError:error];


### PR DESCRIPTION
set the  property `readyState` in the `_workQueue ` thread.
get property `readyState` some in main thread, and some in the same thread where set.
--
So it causes data racing,when set in `_workQueue` thread and get in main thread.

I met several times in `- (void)open`. 
So change the geting in `_workQueue`thread.
