### PR TITLE
Support using TLS 1.3

### DIFF
--- a/SocketRocket/SRSecurityPolicy.m
+++ b/SocketRocket/SRSecurityPolicy.m
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateSecurityOptionsInStream:(NSStream *)stream
 {
     // Enforce TLS 1.2
-    [stream setProperty:(__bridge id)CFSTR("kCFStreamSocketSecurityLevelTLSv1_2") forKey:(__bridge id)kCFStreamPropertySocketSecurityLevel];
+    [stream setProperty:(__bridge id)kCFStreamSocketSecurityLevelNegotiatedSSL forKey:(__bridge id)kCFStreamPropertySocketSecurityLevel];
 
     // Validate certificate chain for this stream if enabled.
     NSDictionary<NSString *, id> *sslOptions = @{ (__bridge NSString *)kCFStreamSSLValidatesCertificateChain : @(self.certificateChainValidationEnabled) };

--- a/SocketRocket/SRSecurityPolicy.m
+++ b/SocketRocket/SRSecurityPolicy.m
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateSecurityOptionsInStream:(NSStream *)stream
 {
-    // Enforce TLS 1.2
+    // Enforce TLS >= 1.2
     [stream setProperty:(__bridge id)kCFStreamSocketSecurityLevelNegotiatedSSL forKey:(__bridge id)kCFStreamPropertySocketSecurityLevel];
 
     // Validate certificate chain for this stream if enabled.


### PR DESCRIPTION
kCFStreamSocketSecurityLevelNegotiatedSSL is the only public non-deprecated constant which should negotiate connections with TLS >= 1.2.